### PR TITLE
Provider Icons for Nodes (LLM, Integration, Database)

### DIFF
--- a/frontend/src/canvas/nodes/BaseNode.tsx
+++ b/frontend/src/canvas/nodes/BaseNode.tsx
@@ -1,5 +1,5 @@
-import { LucideIcon, GripHorizontal, ArrowLeftRight } from "lucide-react";
-import { ReactNode, useState, useEffect } from "react";
+import { GripHorizontal, ArrowLeftRight } from "lucide-react";
+import { useState, useEffect } from "react";
 import { Handle, Position, useNodeId, useStore, useUpdateNodeInternals } from "reactflow";
 import { NodeExecutionPopover } from "../../components/execution/NodeExecutionPopover";
 import { cn } from "../../lib/utils";
@@ -8,13 +8,14 @@ import {
     INITIAL_NODE_WIDTH,
     INITIAL_NODE_HEIGHT
 } from "../../stores/workflowStore";
+import type { CSSProperties, ElementType, ReactNode } from "react";
 
 export type NodeStatus = "idle" | "pending" | "running" | "success" | "error";
 
 export type ConnectorLayout = "vertical" | "horizontal";
 
 interface BaseNodeProps {
-    icon: LucideIcon;
+    icon: ElementType<{ className?: string }>;
     label: string;
     status?: NodeStatus;
     category?: "ai" | "logic" | "interaction" | "data" | "connect" | "voice";
@@ -25,6 +26,9 @@ interface BaseNodeProps {
     customHandles?: ReactNode;
     onStatusClick?: () => void;
     connectorLayout?: ConnectorLayout;
+    iconClassName?: string;
+    iconWrapperClassName?: string;
+    iconWrapperStyle?: CSSProperties;
 }
 
 const statusConfig: Record<NodeStatus, { color: string; label: string }> = {
@@ -82,7 +86,10 @@ export function BaseNode({
     hasOutputHandle = true,
     customHandles,
     onStatusClick,
-    connectorLayout: connectorLayoutProp = "horizontal"
+    connectorLayout: connectorLayoutProp = "horizontal",
+    iconClassName,
+    iconWrapperClassName,
+    iconWrapperStyle
 }: BaseNodeProps) {
     const nodeId = useNodeId();
     const { currentExecution, selectedNode } = useWorkflowStore();
@@ -271,8 +278,18 @@ export function BaseNode({
             {/* Header */}
             <div className="flex items-center justify-between px-3 py-2.5 border-b border-border bg-muted/30">
                 <div className="flex items-center gap-2.5">
-                    <div className={cn("p-1.5 rounded-md", categoryStyle.iconBg)}>
-                        <Icon className={cn("w-3.5 h-3.5", categoryStyle.iconColor)} />
+                    <div
+                        className={cn(
+                            "p-1.5 rounded-md flex items-center justify-center",
+                            categoryStyle.iconBg,
+                            categoryStyle.iconColor,
+                            iconWrapperClassName
+                        )}
+                        style={iconWrapperStyle}
+                    >
+                        <Icon
+                            className={cn("w-3.5 h-3.5", categoryStyle.iconColor, iconClassName)}
+                        />
                     </div>
                     <span className="font-medium text-sm text-foreground">{label}</span>
                 </div>
@@ -337,8 +354,6 @@ export function BaseNode({
                     className="
                         w-4 h-4
                         flex items-center justify-center
-                        rounded
-                        bg-muted/70 hover:bg-muted
                         text-muted-foreground hover:text-foreground
                         mb-[2px]
                     "

--- a/frontend/src/canvas/nodes/DatabaseNode.tsx
+++ b/frontend/src/canvas/nodes/DatabaseNode.tsx
@@ -1,6 +1,7 @@
 import { Database } from "lucide-react";
 import { memo } from "react";
 import { NodeProps } from "reactflow";
+import { ALL_PROVIDERS } from "@flowmaestro/shared";
 import { BaseNode } from "./BaseNode";
 
 interface DatabaseNodeData {
@@ -11,8 +12,20 @@ interface DatabaseNodeData {
 }
 
 function DatabaseNode({ data, selected }: NodeProps<DatabaseNodeData>) {
-    const provider = data.provider;
+    const provider = data.provider?.toLocaleLowerCase();
     const operation = data.operation;
+
+    const providerMeta = ALL_PROVIDERS.find((p) => p.provider === provider);
+
+    const providerLogoUrl = providerMeta?.logoUrl;
+    const providerBorderColor = providerMeta?.brandColor;
+    const ProviderLogo = ({ className }: { className?: string }) => (
+        <img
+            src={providerLogoUrl}
+            alt={providerMeta?.displayName || "Provider logo"}
+            className={`${className ?? ""} object-contain`}
+        />
+    );
 
     // Format provider name for display (PostgreSQL, MySQL, MongoDB)
     const formatProvider = (providerStr: string): string => {
@@ -34,7 +47,14 @@ function DatabaseNode({ data, selected }: NodeProps<DatabaseNodeData>) {
 
     return (
         <BaseNode
-            icon={Database}
+            icon={providerLogoUrl ? ProviderLogo : Database}
+            iconClassName={providerLogoUrl ? "w-5 h-5 rounded" : undefined}
+            iconWrapperClassName={providerLogoUrl ? "p-1 w-7 h-7 border bg-muted/30" : undefined}
+            iconWrapperStyle={
+                providerLogoUrl && providerBorderColor
+                    ? { borderColor: providerBorderColor }
+                    : undefined
+            }
             label={data.label || "Database"}
             status={data.status}
             category="connect"

--- a/frontend/src/canvas/nodes/IntegrationNode.tsx
+++ b/frontend/src/canvas/nodes/IntegrationNode.tsx
@@ -1,6 +1,7 @@
 import { Plug } from "lucide-react";
 import { memo } from "react";
 import { NodeProps } from "reactflow";
+import { ALL_PROVIDERS } from "@flowmaestro/shared";
 import { BaseNode } from "./BaseNode";
 
 interface IntegrationNodeData {
@@ -11,8 +12,20 @@ interface IntegrationNodeData {
 }
 
 function IntegrationNode({ data, selected }: NodeProps<IntegrationNodeData>) {
-    const provider = data.provider;
+    const provider = data.provider?.toLocaleLowerCase();
     const operation = data.operation;
+
+    const providerMeta = ALL_PROVIDERS.find((p) => p.provider === provider);
+
+    const providerLogoUrl = providerMeta?.logoUrl;
+    const providerBorderColor = providerMeta?.brandColor;
+    const ProviderLogo = ({ className }: { className?: string }) => (
+        <img
+            src={providerLogoUrl}
+            alt={providerMeta?.displayName || "Provider logo"}
+            className={`${className ?? ""} object-contain`}
+        />
+    );
 
     // Format operation for display: handle both snake_case and camelCase
     const formatOperation = (opStr: string): string => {
@@ -26,7 +39,14 @@ function IntegrationNode({ data, selected }: NodeProps<IntegrationNodeData>) {
 
     return (
         <BaseNode
-            icon={Plug}
+            icon={providerLogoUrl ? ProviderLogo : Plug}
+            iconClassName={providerLogoUrl ? "w-5 h-5 rounded" : undefined}
+            iconWrapperClassName={providerLogoUrl ? "p-1 w-7 h-7 border bg-muted/30" : undefined}
+            iconWrapperStyle={
+                providerLogoUrl && providerBorderColor
+                    ? { borderColor: providerBorderColor }
+                    : undefined
+            }
             label={data.label || "Integration"}
             status={data.status}
             category="connect"

--- a/frontend/src/canvas/nodes/LLMNode.tsx
+++ b/frontend/src/canvas/nodes/LLMNode.tsx
@@ -1,6 +1,7 @@
 import { Bot } from "lucide-react";
 import { memo } from "react";
 import { NodeProps } from "reactflow";
+import { ALL_PROVIDERS } from "@flowmaestro/shared";
 import { BaseNode } from "./BaseNode";
 
 interface LLMNodeData {
@@ -12,15 +13,34 @@ interface LLMNodeData {
 }
 
 function LLMNode({ data, selected }: NodeProps<LLMNodeData>) {
-    const provider = data.provider || "OpenAI";
+    const provider = data.provider?.toLocaleLowerCase();
     const model = data.model || "gpt-4";
     const promptPreview = data.prompt
         ? data.prompt.substring(0, 50) + (data.prompt.length > 50 ? "..." : "")
         : "No prompt configured";
 
+    const providerMeta = ALL_PROVIDERS.find((p) => p.provider === provider);
+
+    const providerLogoUrl = providerMeta?.logoUrl;
+    const providerBorderColor = providerMeta?.brandColor;
+    const ProviderLogo = ({ className }: { className?: string }) => (
+        <img
+            src={providerLogoUrl}
+            alt={providerMeta?.displayName || "Provider logo"}
+            className={`${className ?? ""} object-contain`}
+        />
+    );
+
     return (
         <BaseNode
-            icon={Bot}
+            icon={providerLogoUrl ? ProviderLogo : Bot}
+            iconClassName={providerLogoUrl ? "w-5 h-5 rounded" : undefined}
+            iconWrapperClassName={providerLogoUrl ? "p-1 w-7 h-7 border bg-muted/30" : undefined}
+            iconWrapperStyle={
+                providerLogoUrl && providerBorderColor
+                    ? { borderColor: providerBorderColor }
+                    : undefined
+            }
             label={data.label || "LLM"}
             status={data.status}
             category="ai"
@@ -29,7 +49,9 @@ function LLMNode({ data, selected }: NodeProps<LLMNodeData>) {
             <div className="space-y-2">
                 <div className="flex items-center justify-between">
                     <span className="text-xs text-muted-foreground">Provider:</span>
-                    <span className="text-xs font-medium">{provider}</span>
+                    <span className="text-xs font-medium">
+                        {providerMeta?.displayName || data.provider || "Unknown"}
+                    </span>
                 </div>
                 <div className="flex items-center justify-between">
                     <span className="text-xs text-muted-foreground">Model:</span>

--- a/shared/src/providers.ts
+++ b/shared/src/providers.ts
@@ -35,6 +35,7 @@ export interface Provider {
     displayName: string;
     description: string;
     logoUrl: string;
+    brandColor?: string;
     category: string;
     methods: ConnectionMethod[];
     comingSoon?: boolean;
@@ -58,6 +59,7 @@ export const ALL_PROVIDERS: Provider[] = [
         displayName: "OpenAI",
         description: "GPT models and AI capabilities",
         logoUrl: getBrandLogo("openai.com"),
+        brandColor: "#000000",
         category: "AI & ML",
         methods: ["api_key"]
     },
@@ -66,6 +68,7 @@ export const ALL_PROVIDERS: Provider[] = [
         displayName: "Anthropic",
         description: "Claude AI assistant",
         logoUrl: getBrandLogo("anthropic.com"),
+        brandColor: "#141414",
         category: "AI & ML",
         methods: ["api_key"]
     },
@@ -74,6 +77,7 @@ export const ALL_PROVIDERS: Provider[] = [
         displayName: "Google AI",
         description: "Gemini models with vision, audio, and massive context windows",
         logoUrl: getBrandLogo("google.com"),
+        brandColor: "#4285F4",
         category: "AI & ML",
         methods: ["api_key"]
     },
@@ -82,6 +86,7 @@ export const ALL_PROVIDERS: Provider[] = [
         displayName: "Hugging Face",
         description: "Access thousands of open-source AI models including Llama, Qwen, and Mistral",
         logoUrl: getBrandLogo("huggingface.co"),
+        brandColor: "#FFB000",
         category: "AI & ML",
         methods: ["api_key"]
     },
@@ -92,6 +97,7 @@ export const ALL_PROVIDERS: Provider[] = [
         displayName: "Slack",
         description: "Send messages and manage channels",
         logoUrl: getBrandLogo("slack.com"),
+        brandColor: "#4A154B",
         category: "Communication",
         methods: ["oauth2"]
     },
@@ -178,6 +184,7 @@ export const ALL_PROVIDERS: Provider[] = [
         displayName: "Airtable",
         description: "Manage records, bases, and collaborate in Airtable",
         logoUrl: getBrandLogo("airtable.com"),
+        brandColor: "#18BFFF",
         category: "Productivity",
         methods: ["oauth2"]
     },
@@ -415,6 +422,7 @@ export const ALL_PROVIDERS: Provider[] = [
         displayName: "LinkedIn",
         description: "Create posts, share articles, manage comments and reactions on LinkedIn",
         logoUrl: getBrandLogo("linkedin.com"),
+        brandColor: "#0A66C2",
         category: "Social Media",
         methods: ["oauth2"]
     },
@@ -1466,6 +1474,7 @@ export const ALL_PROVIDERS: Provider[] = [
         displayName: "MongoDB",
         description: "NoSQL database platform",
         logoUrl: getBrandLogo("mongodb.com"),
+        brandColor: "#47A248",
         category: "Databases",
         methods: ["api_key"]
     },
@@ -1474,6 +1483,7 @@ export const ALL_PROVIDERS: Provider[] = [
         displayName: "PostgreSQL",
         description: "Relational database",
         logoUrl: getBrandLogo("postgrespro.com"),
+        brandColor: "#336791",
         category: "Databases",
         methods: ["api_key"]
     },
@@ -1482,6 +1492,7 @@ export const ALL_PROVIDERS: Provider[] = [
         displayName: "MySQL",
         description: "Relational database",
         logoUrl: getBrandLogo("mysql.com"),
+        brandColor: "#4479A1",
         category: "Databases",
         methods: ["api_key"],
         comingSoon: true


### PR DESCRIPTION
## Provider Icons for Nodes (LLM, Integration, Database)

### Summary
This PR updates node headers to display provider-specific icons instead of generic icons, using provider metadata already defined in `ALL_PROVIDERS`. This aligns node visuals with the Connections page and makes workflows easier to scan at a glance.

### What’s included
- **LLM Node**
  - Displays the selected provider’s logo in the header
  - Icon updates dynamically when the provider changes
- **Integration Node**
  - Displays provider logo when a provider is present
  - Falls back to generic icon when no provider is set
- **Database Node**
  - Displays database provider logo (e.g. PostgreSQL, MySQL, MongoDB)
- **Shared behavior**
  - Icons are sourced from `ALL_PROVIDERS.logoUrl` (Brandfetch)

### UX / Layout Improvements
- Updated `BaseNode` to support both Lucide icons and JSX-based icons (images)
- Fixed icon sizing so brand logos scale correctly within the icon container