### PR TITLE
Persisting Folder Visibility

### DIFF
--- a/frontend/src/components/ThemeProvider.tsx
+++ b/frontend/src/components/ThemeProvider.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { useThemeStore } from "../stores/themeStore";
+import { useUIPreferencesStore } from "../stores/uiPreferencesStore";
 
 interface ThemeProviderProps {
     children: React.ReactNode;
@@ -7,11 +8,14 @@ interface ThemeProviderProps {
 
 export function ThemeProvider({ children }: ThemeProviderProps) {
     const initializeTheme = useThemeStore((state) => state.initializeTheme);
+    const initializePreferences = useUIPreferencesStore((state) => state.initializePreferences);
 
     useEffect(() => {
         // Initialize theme on mount
         initializeTheme();
-    }, [initializeTheme]);
+        // Initialize UI preferences on mount
+        initializePreferences();
+    }, [initializeTheme, initializePreferences]);
 
     return <>{children}</>;
 }

--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -33,6 +33,7 @@ import { logger } from "../lib/logger";
 import { createDragPreview } from "../lib/utils";
 import { useAgentStore } from "../stores/agentStore";
 import { buildFolderTree } from "../stores/folderStore";
+import { useUIPreferencesStore } from "../stores/uiPreferencesStore";
 import type { Agent } from "../lib/api";
 
 // Convert local Agent to AgentSummary for card components
@@ -69,7 +70,7 @@ export function Agents() {
         type: "agent" | "folder";
     }>({ isOpen: false, position: { x: 0, y: 0 }, type: "agent" });
     const [isBatchDeleting, setIsBatchDeleting] = useState(false);
-    const [showFoldersSection, setShowFoldersSection] = useState(false);
+    const { showFoldersSection, setShowFoldersSection } = useUIPreferencesStore();
     const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
     const [isCreateFolderDialogOpen, setIsCreateFolderDialogOpen] = useState(false);
     const [isMoveDialogOpen, setIsMoveDialogOpen] = useState(false);

--- a/frontend/src/pages/ChatInterfacesPage.tsx
+++ b/frontend/src/pages/ChatInterfacesPage.tsx
@@ -40,6 +40,7 @@ import {
 import { logger } from "../lib/logger";
 import { createDragPreview } from "../lib/utils";
 import { buildFolderTree } from "../stores/folderStore";
+import { useUIPreferencesStore } from "../stores/uiPreferencesStore";
 
 // Convert ChatInterface to ChatInterfaceSummary for card components
 function toChatInterfaceSummary(ci: ChatInterface): ChatInterfaceSummary {
@@ -88,7 +89,7 @@ export function ChatInterfacesPage() {
     // Selection state
     const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
     const [isBatchDeleting, setIsBatchDeleting] = useState(false);
-    const [showFoldersSection, setShowFoldersSection] = useState(false);
+    const { showFoldersSection, setShowFoldersSection } = useUIPreferencesStore();
     const [contextMenu, setContextMenu] = useState<{
         isOpen: boolean;
         position: { x: number; y: number };

--- a/frontend/src/pages/FormInterfaces.tsx
+++ b/frontend/src/pages/FormInterfaces.tsx
@@ -40,6 +40,7 @@ import {
 import { logger } from "../lib/logger";
 import { createDragPreview } from "../lib/utils";
 import { buildFolderTree } from "../stores/folderStore";
+import { useUIPreferencesStore } from "../stores/uiPreferencesStore";
 
 // Convert FormInterface to FormInterfaceSummary for card components
 function toFormInterfaceSummary(fi: FormInterface): FormInterfaceSummary {
@@ -87,7 +88,7 @@ export function FormInterfaces() {
     const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
     const [selectedFolderIds, setSelectedFolderIds] = useState<Set<string>>(new Set());
     const [isBatchDeleting, setIsBatchDeleting] = useState(false);
-    const [showFoldersSection, setShowFoldersSection] = useState(false);
+    const { showFoldersSection, setShowFoldersSection } = useUIPreferencesStore();
     const [contextMenu, setContextMenu] = useState<{
         isOpen: boolean;
         position: { x: number; y: number };

--- a/frontend/src/pages/KnowledgeBases.tsx
+++ b/frontend/src/pages/KnowledgeBases.tsx
@@ -34,6 +34,7 @@ import { logger } from "../lib/logger";
 import { createDragPreview } from "../lib/utils";
 import { buildFolderTree } from "../stores/folderStore";
 import { useKnowledgeBaseStore } from "../stores/knowledgeBaseStore";
+import { useUIPreferencesStore } from "../stores/uiPreferencesStore";
 
 // Convert KnowledgeBase + stats to KnowledgeBaseSummary for card components
 function toKnowledgeBaseSummary(
@@ -71,7 +72,7 @@ export function KnowledgeBases() {
         type: "kb" | "folder";
     }>({ isOpen: false, position: { x: 0, y: 0 }, type: "kb" });
     const [isBatchDeleting, setIsBatchDeleting] = useState(false);
-    const [showFoldersSection, setShowFoldersSection] = useState(false);
+    const { showFoldersSection, setShowFoldersSection } = useUIPreferencesStore();
 
     // Folder state
     const [folders, setFolders] = useState<FolderWithCounts[]>([]);

--- a/frontend/src/pages/Workflows.tsx
+++ b/frontend/src/pages/Workflows.tsx
@@ -42,6 +42,7 @@ import { logger } from "../lib/logger";
 import { createDragPreview } from "../lib/utils";
 import { convertToReactFlowFormat } from "../lib/workflowLayout";
 import { buildFolderTree } from "../stores/folderStore";
+import { useUIPreferencesStore } from "../stores/uiPreferencesStore";
 import { useWorkflowGenerationChatStore } from "../stores/workflowGenerationChatStore";
 
 // Local workflow type that maps to API response (snake_case) and WorkflowSummary (camelCase)
@@ -114,7 +115,7 @@ export function Workflows() {
         type: "workflow" | "folder";
     }>({ isOpen: false, position: { x: 0, y: 0 }, type: "workflow" });
     const [isBatchDeleting, setIsBatchDeleting] = useState(false);
-    const [showFoldersSection, setShowFoldersSection] = useState(false);
+    const { showFoldersSection, setShowFoldersSection } = useUIPreferencesStore();
     const navigate = useNavigate();
 
     // Search functionality

--- a/frontend/src/stores/uiPreferencesStore.ts
+++ b/frontend/src/stores/uiPreferencesStore.ts
@@ -1,0 +1,68 @@
+import { create } from "zustand";
+import { logger } from "../lib/logger";
+
+interface UIPreferencesStore {
+    showFoldersSection: boolean;
+    setShowFoldersSection: (show: boolean) => void;
+    initializePreferences: () => void;
+}
+
+const STORAGE_KEY = "ui_preferences";
+
+interface StoredPreferences {
+    showFoldersSection: boolean;
+}
+
+const defaultPreferences: StoredPreferences = {
+    showFoldersSection: false
+};
+
+export const useUIPreferencesStore = create<UIPreferencesStore>((set) => ({
+    showFoldersSection: false,
+
+    setShowFoldersSection: (show: boolean) => {
+        // Save to localStorage
+        const stored = getStoredPreferences();
+        const updated: StoredPreferences = {
+            ...stored,
+            showFoldersSection: show
+        };
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+
+        // Update state
+        set({ showFoldersSection: show });
+    },
+
+    initializePreferences: () => {
+        // Load from localStorage or use defaults
+        const stored = getStoredPreferences();
+
+        // Update state
+        set({
+            showFoldersSection: stored.showFoldersSection
+        });
+    }
+}));
+
+// Helper to get stored preferences
+function getStoredPreferences(): StoredPreferences {
+    if (typeof window === "undefined") {
+        return defaultPreferences;
+    }
+
+    try {
+        const stored = localStorage.getItem(STORAGE_KEY);
+        if (stored) {
+            const parsed = JSON.parse(stored) as Partial<StoredPreferences>;
+            return {
+                ...defaultPreferences,
+                ...parsed
+            };
+        }
+    } catch (error) {
+        // If parsing fails, return defaults
+        logger.error("Failed to parse stored UI preferences", error);
+    }
+
+    return defaultPreferences;
+}


### PR DESCRIPTION
- Add UI preferences store with localStorage persistence
- Replace local state with shared store in all folder-enabled pages
- Initialize preferences on app startup via ThemeProvider

Fixes issue where folder visibility toggle would reset when exiting or deleting folders, requiring users to re-enable it each time.

Affected pages:
- Workflows
- Agents
- Knowledge Bases
- Form Interfaces
- Chat Interfaces