### PR TITLE
Auto-collapse Folder Sections

### DIFF
--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -203,8 +203,10 @@ export function Agents() {
                     return newSet;
                 });
             } else if (selectedFolderIds.size === 0) {
-                // Navigate to unified folder contents page
-                navigate(`/folders/${folder.id}`);
+                // Navigate to unified folder contents page with source type for auto-collapse
+                navigate(`/folders/${folder.id}`, {
+                    state: { sourceItemType: "agent" }
+                });
             } else {
                 setSelectedFolderIds(new Set());
             }

--- a/frontend/src/pages/ChatInterfacesPage.tsx
+++ b/frontend/src/pages/ChatInterfacesPage.tsx
@@ -265,8 +265,10 @@ export function ChatInterfacesPage() {
                     return newSet;
                 });
             } else if (selectedFolderIds.size === 0) {
-                // Navigate to unified folder contents page
-                navigate(`/folders/${folder.id}`);
+                // Navigate to unified folder contents page with source type for auto-collapse
+                navigate(`/folders/${folder.id}`, {
+                    state: { sourceItemType: "chat-interface" }
+                });
             } else {
                 setSelectedFolderIds(new Set());
             }

--- a/frontend/src/pages/FolderContentsPage.tsx
+++ b/frontend/src/pages/FolderContentsPage.tsx
@@ -9,7 +9,7 @@ import {
     Check
 } from "lucide-react";
 import { useEffect, useState, useRef } from "react";
-import { useParams, useNavigate, Link } from "react-router-dom";
+import { useParams, useNavigate, Link, useLocation } from "react-router-dom";
 import type { FolderResourceType, Folder as FolderType } from "@flowmaestro/shared";
 import { MAX_FOLDER_DEPTH } from "@flowmaestro/shared";
 import { Button } from "../components/common/Button";
@@ -23,6 +23,11 @@ import { useFolderStore } from "../stores/folderStore";
 export function FolderContentsPage() {
     const { folderId } = useParams<{ folderId: string }>();
     const navigate = useNavigate();
+    const location = useLocation();
+
+    // Get source item type from navigation state for auto-collapse
+    const sourceItemType = (location.state as { sourceItemType?: FolderResourceType } | null)
+        ?.sourceItemType;
 
     const {
         currentFolderContents,
@@ -371,6 +376,9 @@ export function FolderContentsPage() {
                         items={items.workflows}
                         folderId={folder.id}
                         onRemoveFromFolder={handleRemoveFromFolder}
+                        defaultCollapsed={
+                            sourceItemType !== undefined && sourceItemType !== "workflow"
+                        }
                     />
 
                     <FolderItemSection
@@ -379,6 +387,9 @@ export function FolderContentsPage() {
                         items={items.agents}
                         folderId={folder.id}
                         onRemoveFromFolder={handleRemoveFromFolder}
+                        defaultCollapsed={
+                            sourceItemType !== undefined && sourceItemType !== "agent"
+                        }
                     />
 
                     <FolderItemSection
@@ -387,6 +398,9 @@ export function FolderContentsPage() {
                         items={items.formInterfaces}
                         folderId={folder.id}
                         onRemoveFromFolder={handleRemoveFromFolder}
+                        defaultCollapsed={
+                            sourceItemType !== undefined && sourceItemType !== "form-interface"
+                        }
                     />
 
                     <FolderItemSection
@@ -395,6 +409,9 @@ export function FolderContentsPage() {
                         items={items.chatInterfaces}
                         folderId={folder.id}
                         onRemoveFromFolder={handleRemoveFromFolder}
+                        defaultCollapsed={
+                            sourceItemType !== undefined && sourceItemType !== "chat-interface"
+                        }
                     />
 
                     <FolderItemSection
@@ -403,6 +420,9 @@ export function FolderContentsPage() {
                         items={items.knowledgeBases}
                         folderId={folder.id}
                         onRemoveFromFolder={handleRemoveFromFolder}
+                        defaultCollapsed={
+                            sourceItemType !== undefined && sourceItemType !== "knowledge-base"
+                        }
                     />
                 </div>
             ) : null}

--- a/frontend/src/pages/FormInterfaces.tsx
+++ b/frontend/src/pages/FormInterfaces.tsx
@@ -264,8 +264,10 @@ export function FormInterfaces() {
                     return newSet;
                 });
             } else if (selectedFolderIds.size === 0) {
-                // Navigate to unified folder contents page
-                navigate(`/folders/${folder.id}`);
+                // Navigate to unified folder contents page with source type for auto-collapse
+                navigate(`/folders/${folder.id}`, {
+                    state: { sourceItemType: "form-interface" }
+                });
             } else {
                 setSelectedFolderIds(new Set());
             }

--- a/frontend/src/pages/KnowledgeBases.tsx
+++ b/frontend/src/pages/KnowledgeBases.tsx
@@ -237,8 +237,10 @@ export function KnowledgeBases() {
                     return newSet;
                 });
             } else if (selectedFolderIds.size === 0) {
-                // Navigate to unified folder contents page
-                navigate(`/folders/${folder.id}`);
+                // Navigate to unified folder contents page with source type for auto-collapse
+                navigate(`/folders/${folder.id}`, {
+                    state: { sourceItemType: "knowledge-base" }
+                });
             } else {
                 setSelectedFolderIds(new Set());
             }

--- a/frontend/src/pages/Workflows.tsx
+++ b/frontend/src/pages/Workflows.tsx
@@ -406,8 +406,10 @@ export function Workflows() {
                     return newSet;
                 });
             } else if (selectedFolderIds.size === 0) {
-                // Navigate to unified folder contents page
-                navigate(`/folders/${folder.id}`);
+                // Navigate to unified folder contents page with source type for auto-collapse
+                navigate(`/folders/${folder.id}`, {
+                    state: { sourceItemType: "workflow" }
+                });
             } else {
                 // Clear selection on normal click when folders are selected
                 setSelectedFolderIds(new Set());


### PR DESCRIPTION
auto-collapse folder sections based on source page type when navigating to a folder from a specific page type (workflows, agents, etc.), automatically collapse other item type sections to focus on the relevant content and reduce scrolling.