### PR TITLE
Fixed MD format for threadChat

### DIFF
--- a/frontend/src/components/agents/ThreadChat.tsx
+++ b/frontend/src/components/agents/ThreadChat.tsx
@@ -1,5 +1,7 @@
 import { Send, Bot, User, Loader2, Wrench, CheckCircle2, XCircle, Eye } from "lucide-react";
 import { useState, useEffect, useRef, useCallback } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import * as api from "../../lib/api";
 import { streamAgentExecution } from "../../lib/api";
 import { logger } from "../../lib/logger";
@@ -449,9 +451,81 @@ export function ThreadChat({ agent, thread }: ThreadChatProps) {
                                                   : "bg-muted text-foreground"
                                         )}
                                     >
-                                        <div className="whitespace-pre-wrap break-words">
-                                            {message.content}
-                                        </div>
+                                        {message.role === "system" ? (
+                                            <div className="whitespace-pre-wrap break-words">
+                                                {message.content}
+                                            </div>
+                                        ) : (
+                                            <div
+                                                className={cn(
+                                                    "text-sm prose max-w-none",
+                                                    message.role === "user"
+                                                        ? "prose-invert prose-sm"
+                                                        : "prose-sm dark:prose-invert"
+                                                )}
+                                            >
+                                                <ReactMarkdown
+                                                    remarkPlugins={[remarkGfm]}
+                                                    components={{
+                                                        h1: ({ children }) => (
+                                                            <h1 className="text-lg font-bold mt-4 mb-2 pb-2 border-b border-border">
+                                                                {children}
+                                                            </h1>
+                                                        ),
+                                                        h2: ({ children }) => (
+                                                            <h2 className="text-base font-bold mt-3 mb-2 pb-1 border-b border-border">
+                                                                {children}
+                                                            </h2>
+                                                        ),
+                                                        h3: ({ children }) => (
+                                                            <h3 className="text-sm font-bold mt-2 mb-1">
+                                                                {children}
+                                                            </h3>
+                                                        ),
+                                                        ul: ({ children }) => (
+                                                            <ul className="list-disc list-inside my-2 space-y-1">
+                                                                {children}
+                                                            </ul>
+                                                        ),
+                                                        ol: ({ children }) => (
+                                                            <ol className="list-decimal list-inside my-2 space-y-1">
+                                                                {children}
+                                                            </ol>
+                                                        ),
+                                                        li: ({ children }) => (
+                                                            <li className="ml-2">{children}</li>
+                                                        ),
+                                                        p: ({ children }) => (
+                                                            <p className="my-1.5">{children}</p>
+                                                        ),
+                                                        strong: ({ children }) => (
+                                                            <strong className="font-semibold">
+                                                                {children}
+                                                            </strong>
+                                                        ),
+                                                        code: ({ children, className }) => {
+                                                            const isInline = !className;
+                                                            return isInline ? (
+                                                                <code className="px-1.5 py-0.5 rounded bg-muted-foreground/10 text-foreground font-mono text-xs">
+                                                                    {children}
+                                                                </code>
+                                                            ) : (
+                                                                <code className="block px-3 py-2 rounded bg-muted-foreground/10 text-foreground font-mono text-xs overflow-x-auto">
+                                                                    {children}
+                                                                </code>
+                                                            );
+                                                        },
+                                                        blockquote: ({ children }) => (
+                                                            <blockquote className="border-l-2 border-primary pl-3 italic my-2">
+                                                                {children}
+                                                            </blockquote>
+                                                        )
+                                                    }}
+                                                >
+                                                    {message.content}
+                                                </ReactMarkdown>
+                                            </div>
+                                        )}
                                     </div>
                                     {message.role === "user" && (
                                         <div className="w-8 h-8 rounded-lg bg-secondary flex items-center justify-center flex-shrink-0">


### PR DESCRIPTION
## Changes Made

### `frontend/src/components/agents/ThreadChat.tsx`
- **Added imports**: `ReactMarkdown` and `remarkGfm` for Markdown rendering
- **Replaced plain text rendering**: Changed from `whitespace-pre-wrap` to `ReactMarkdown` component with custom styling components
- **Applied consistent styling**:
  - User messages: `prose-invert` styling (for primary background)
  - Assistant messages: `prose` with `dark:prose-invert` (for muted background)
  - System messages: Kept as plain text (simple italic messages don't need Markdown)

### Markdown Components Supported
- Headers (h1, h2, h3) with proper styling and borders
- Lists (ordered and unordered) with proper spacing
- Code blocks (inline and block) with syntax highlighting backgrounds
- Bold text (`strong` tags)
- Blockquotes with left border styling
- Paragraphs with proper spacing