### PR TITLE
Add client-side API key validation

### DIFF
--- a/frontend/src/lib/connectionValidation.ts
+++ b/frontend/src/lib/connectionValidation.ts
@@ -1,0 +1,216 @@
+/**
+ * API Key validation utilities
+ * Provides provider-specific validation rules for API keys
+ */
+
+export interface ValidationResult {
+    valid: boolean;
+    error?: string;
+}
+
+interface ProviderValidationRules {
+    minLength: number;
+    startsWith?: string[];
+    noSpaces?: boolean;
+    customValidator?: (key: string) => ValidationResult;
+}
+
+// Validation rules for different providers
+
+const PROVIDER_RULES: Record<string, ProviderValidationRules> = {
+    openai: {
+        minLength: 20,
+        // OpenAI supports multiple key formats:
+        // - sk-proj- (new project-based keys, can be up to 164 chars)
+        // - sk- (legacy keys, ~48 chars)
+        // - sk-None- (user profile keys)
+        // - sk-svcacct- (service account keys)
+        startsWith: ["sk-proj-", "sk-", "sk-none-", "sk-svcacct-"],
+        noSpaces: true
+    },
+    anthropic: {
+        minLength: 50,
+        // Anthropic keys start with sk-ant-api03- followed by 48 chars (total 60+)
+        startsWith: ["sk-ant-api03-"],
+        noSpaces: true
+    },
+    google: {
+        minLength: 35,
+        // Google API keys start with AIzaSy and are typically 39 characters
+        startsWith: ["AIzaSy"],
+        noSpaces: true
+    },
+    huggingface: {
+        minLength: 10,
+        // Hugging Face tokens start with hf_
+        startsWith: ["hf_"],
+        noSpaces: true
+    },
+    cohere: {
+        minLength: 45,
+        // Cohere keys start with co_ followed by 48 characters (total 51)
+        startsWith: ["co_"],
+        noSpaces: true
+    },
+    github: {
+        minLength: 20,
+        // GitHub tokens typically start with ghp_, gho_, ghu_, ghs_, or ghr_
+        startsWith: ["ghp_", "gho_", "ghu_", "ghs_", "ghr_"],
+        noSpaces: true
+    },
+    coda: {
+        minLength: 20,
+        // Coda API tokens don't have a specific prefix pattern
+        noSpaces: true
+    },
+    fal: {
+        minLength: 20,
+        // FAL.ai API keys - no specific prefix pattern found
+        noSpaces: true
+    },
+    // Default rules for unknown providers
+    default: {
+        minLength: 10,
+        noSpaces: true
+    }
+};
+
+// Validate an API key based on provider-specific rules
+
+export function validateApiKey(apiKey: string, provider: string): ValidationResult {
+    const keyLabel = getApiKeyLabel(provider);
+
+    if (!apiKey || !apiKey.trim()) {
+        return {
+            valid: false,
+            error: `${keyLabel} is required`
+        };
+    }
+
+    const trimmedKey = apiKey.trim();
+    const providerKey = provider.toLowerCase();
+    const rules = PROVIDER_RULES[providerKey] || PROVIDER_RULES.default;
+
+    if (rules.noSpaces !== false && /\s/.test(trimmedKey)) {
+        return {
+            valid: false,
+            error: `${keyLabel} cannot contain spaces. Please remove any spaces from your ${keyLabel.toLowerCase()}.`
+        };
+    }
+
+    if (trimmedKey.length < rules.minLength) {
+        return {
+            valid: false,
+            error: `${keyLabel} is too short. It must be at least ${rules.minLength} characters long.`
+        };
+    }
+
+    if (rules.startsWith && rules.startsWith.length > 0) {
+        const hasValidPrefix = rules.startsWith.some((prefix) =>
+            trimmedKey.toLowerCase().startsWith(prefix.toLowerCase())
+        );
+
+        if (!hasValidPrefix) {
+            const prefixList = rules.startsWith.map((p) => `"${p}"`).join(" or ");
+            return {
+                valid: false,
+                error: `${keyLabel} should start with ${prefixList}. Please check your ${keyLabel.toLowerCase()}.`
+            };
+        }
+    }
+
+    // Run custom validator if provided
+    if (rules.customValidator) {
+        const customResult = rules.customValidator(trimmedKey);
+        if (!customResult.valid) {
+            return customResult;
+        }
+    }
+
+    return { valid: true };
+}
+
+/**
+ * Validate API key in real-time as user types for less strict validation
+ * This is useful for showing warnings without blocking input
+ */
+export function validateApiKeySoft(apiKey: string, provider: string): ValidationResult {
+    if (!apiKey || !apiKey.trim()) {
+        return { valid: true };
+    }
+
+    const keyLabel = getApiKeyLabel(provider);
+    const trimmedKey = apiKey.trim();
+    const providerKey = provider.toLowerCase();
+    const rules = PROVIDER_RULES[providerKey] || PROVIDER_RULES.default;
+
+    if (/\s/.test(trimmedKey)) {
+        return {
+            valid: false,
+            error: `${keyLabel} contains spaces. Please remove them.`
+        };
+    }
+
+    if (trimmedKey.length > 0 && trimmedKey.length < rules.minLength) {
+        return {
+            valid: false,
+            error: `${keyLabel} should be at least ${rules.minLength} characters long`
+        };
+    }
+
+    // Check prefix if the key is long enough only for prefix validation, not blocking
+    // This gives real-time feedback about prefix issues
+    if (rules.startsWith && rules.startsWith.length > 0 && trimmedKey.length >= 3) {
+        const hasValidPrefix = rules.startsWith.some((prefix) =>
+            trimmedKey.toLowerCase().startsWith(prefix.toLowerCase())
+        );
+
+        if (!hasValidPrefix) {
+            // Only show prefix error if the key is getting long enough to have a prefix
+            // This prevents premature errors while user is still typing
+            if (trimmedKey.length >= Math.min(...rules.startsWith.map((p) => p.length))) {
+                const prefixList = rules.startsWith.map((p) => `"${p}"`).join(" or ");
+                return {
+                    valid: false,
+                    error: `${keyLabel} should start with ${prefixList}`
+                };
+            }
+        }
+    }
+
+    return { valid: true };
+}
+
+/**
+ * Get provider display name for error messages
+ */
+export function getProviderDisplayName(provider: string): string {
+    const providerMap: Record<string, string> = {
+        openai: "OpenAI",
+        anthropic: "Anthropic",
+        google: "Google AI",
+        huggingface: "Hugging Face",
+        cohere: "Cohere",
+        github: "GitHub",
+        coda: "Coda",
+        fal: "FAL.ai"
+    };
+
+    return providerMap[provider.toLowerCase()] || provider;
+}
+
+// Get API key label for a provider (e.g., "OpenAI key", "GitHub token")
+function getApiKeyLabel(provider: string): string {
+    const providerKey = provider.toLowerCase();
+
+    // Providers that use "token" instead of "key"
+    const tokenProviders = ["github"];
+
+    const displayName = getProviderDisplayName(provider);
+
+    if (tokenProviders.includes(providerKey)) {
+        return `${displayName} token`;
+    }
+
+    return `${displayName} key`;
+}


### PR DESCRIPTION
## Changes

### New Features
-  Real-time validation feedback as users type API keys
-  Provider-specific validation rules with required prefixes and minimum lengths
-  Automatic error clearing when validation issues are fixed

### Supported Providers
- **OpenAI**: Validates `sk-proj-`, `sk-`, `sk-none-`, or `sk-svcacct-` prefixes (min 20 chars)
- **Anthropic**: Validates `sk-ant-api03-` prefix (min 50 chars)
- **Google AI**: Validates `AIzaSy` prefix (min 35 chars, typically 39)
- **Hugging Face**: Validates `hf_` prefix (min 10 chars)
- **Cohere**: Validates `co_` prefix (min 45 chars)
- **GitHub**: Validates `ghp_`, `gho_`, `ghu_`, `ghs_`, or `ghr_` prefixes (min 20 chars)
- **Coda**: Validates minimum length (min 20 chars, no specific prefix)
- **FAL.ai**: Validates minimum length (min 20 chars, no specific prefix)

### Validation Rules
1. **Spaces**: Detects and prevents spaces in API keys
2. **Length**: Enforces minimum character requirements per provider
3. **Prefix**: Validates required prefixes for providers that have them
4. **Real-time feedback**: Shows warnings as users type without blocking input
